### PR TITLE
fix: fix the CI error

### DIFF
--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,9 +5,8 @@ spring:
     user:
       name: user
       password: pass
-
-  datasource:
-    driver-class-name: com.mysql.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/casbin?useSSL=false
+mysql:
+    url: jdbc:mysql://localhost:3306/casbin?useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC
     username: root
     password: casbin_test
+    driver: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
fix: https://github.com/jcasbin/casbin-spring-security-starter/issues/5

fix: fix the CI error

The issue with the original jdbcTest.java code not being able to load the application file has been fixed.